### PR TITLE
Added hitbox.tv support

### DIFF
--- a/pyfibot/modules/module_urltitle.py
+++ b/pyfibot/modules/module_urltitle.py
@@ -1137,6 +1137,35 @@ def _handle_nettikone(url):
     """http*://*nettikone.com/*/*/*"""
     return fetch_nettiX(url, ['Vuosimalli', 'Osasto', 'Moottorin tilavuus', 'Mittarilukema', 'Polttoaine'])
 
+def _handle_hitbox(url):
+    '''
+    Fetch hitbox.tv stream title from hitbox api. 
+    Webpages are done in angularJS so you can't fetch the title with
+    generic handler.
+    '''
+    
+    streamname = url.rsplit('/',2)[2]
+    api_url = 'http://api.hitbox.tv/media/live/%s' % streamname
+
+    r = bot.get_url(api_url)
+
+    try:
+        data = r.json()
+    except:
+        log.debug('can\'t parse, probably wrong stream name')
+        return 'Stream not found.'
+
+    hitboxname = data['livestream'][0]['media_display_name']
+    streamtitle = data['livestream'][0]['media_status']
+    streamgame = data['livestream'][0]['category_name_short']
+    streamlive = data['livestream'][0]['media_is_live']
+    
+    if streamlive == '1':
+        return '[%s] %s - %s LIVE' % (streamgame,hitboxname,streamtitle)
+    else:
+        return '[%s] %s - %s' & (streamgame,hitboxname,streamtitle)
+
+    return False
 
 # IGNORED TITLES
 def _handle_salakuunneltua(url):


### PR DESCRIPTION
Uses hitbox api to fetch title as the generic handler can't fetch them from the angularJS-based webpage. 

Displays shortname of the game, stream name, stream title and status ([LIVE]/[]). "
ex. "Title: [LoL] Badaas - SoloQ gold top/mid (1080p) ♫♫♫ Vocal Trance ♫♫♫ LIVE"
