### PR TITLE
Configurable delay after authentication, support for Nickserv authentication, some language fixes

### DIFF
--- a/pyfibot/botcore.py
+++ b/pyfibot/botcore.py
@@ -237,13 +237,13 @@ class PyFiBot(irc.IRCClient, CoreCommands):
             authname = self.factory.config['networks']['quakenet'].get('authname', None)
             authpass = self.factory.config['networks']['quakenet'].get('authpass', None)
             if not authname or not authpass:
-		log.info("authname or authpass not found, authentication not attempted")
-		self.joinChannels
+		 log.info("authname or authpass not found, authentication not attempted")
+		 self.joinChannels
             else:
-		log.info("Authenticating...")
-		self.say("Q@CServe.quakenet.org", "AUTH %s %s" % (authname, authpass))
-		log.info("Joining channels after %s second delay" % (authdelay))
-		reactor.callLater(authdelay, self.joinChannels)
+		 log.info("Authenticating...")
+		 self.say("Q@CServe.quakenet.org", "AUTH %s %s" % (authname, authpass))
+		 log.info("Joining channels after %s second delay" % (authdelay))
+		 reactor.callLater(authdelay, self.joinChannels)
 				
     # more generic authentication
         else:


### PR DESCRIPTION
Per need to use the bot in freenode,
1) added support for authenticating to atheme/NickServ services
2) to enable joining after authentication is complete, added a configurable delay (config.yml setting "authdelay: X" - which defaults to zero if no number is given - in seconds) and in that process separated the channel joins to a separate function which the authentication calls
3) fixed some mostly minor language issues, as "signed on" doesn't explicitly mean connecting without authentication
