### PR TITLE
Improve hitbox.tv url title handling

### DIFF
--- a/pyfibot/modules/module_urltitle.py
+++ b/pyfibot/modules/module_urltitle.py
@@ -1145,39 +1145,43 @@ def _handle_nettikone(url):
 def _handle_hitbox(url):
     """http*://*hitbox.tv/*"""
 
-    '''
-    Fetch hitbox.tv stream title from hitbox api.
-    Webpages are done in angularJS so you can't fetch the title with
-    generic handler.
-    '''
+   # Blog and Help subdomains aren't implemented in Angular JS and works fine with default handler
+    if re.match("http://(help|blog)\.hitbox\.tv/.*", url):
+        return
 
-    streamname = url.rsplit('/', 2)[2]
-    api_url = 'http://api.hitbox.tv/media/live/%s' % streamname
+    # Hitbox titles are populated by JavaScript so they return a useless "{{meta.title}}", don't show those
+    elif not re.match("http://(www\.)?hitbox\.tv/([a-z0-9]+)$", url):
+        return False
 
-    r = bot.get_url(api_url)
-
-    try:
-        data = r.json()
-    except:
-        log.debug('can\'t parse, probably wrong stream name')
-        return 'Stream not found.'
-
-    hitboxname = data['livestream'][0]['media_display_name']
-    streamtitle = data['livestream'][0]['media_status']
-    streamgame = data['livestream'][0]['category_name_short']
-    streamlive = data['livestream'][0]['media_is_live']
-
-    if streamgame is None:
-        streamgame = ''
+    # For actual stream pages, let's fetch information via the hitbox API
     else:
-        streamgame = '[%s] ' % (streamgame)
+        streamname = url.rsplit('/',2)[2]
+        api_url = 'http://api.hitbox.tv/media/live/%s' % streamname
 
-    if streamlive == '1':
-        return '%s%s - %s - LIVE' % (streamgame, hitboxname, streamtitle)
-    else:
-        return '%s%s - %s - OFFLINE' % (streamgame, hitboxname, streamtitle)
+        r = bot.get_url(api_url)
 
-    return False
+        try:
+            data = r.json()
+        except:
+            log.debug('can\'t parse, probably wrong stream name')
+            return 'Stream not found.'
+
+        hitboxname = data['livestream'][0]['media_display_name']
+        streamtitle = data['livestream'][0]['media_status']
+        streamgame = data['livestream'][0]['category_name_short']
+        streamlive = data['livestream'][0]['media_is_live']
+
+        if streamgame == None:
+            streamgame = "";
+        else:
+            streamgame = '[%s] ' % (streamgame)
+
+        if streamlive == '1':
+            return '%s%s - %s - LIVE' % (streamgame,hitboxname,streamtitle)
+        else:
+            return '%s%s - %s - OFFLINE' % (streamgame,hitboxname,streamtitle)
+
+        return False
 
 
 def _handle_poliisi(url):


### PR DESCRIPTION
Fetch Help and Blog subdomain titles with the default handler
Fetch only http://(www.)?hitbox.tv/([a-z0-9]+)$ matching urls via the API
