### PR TITLE
.travis.yml: add testing for pypy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python:
   - "2.6"
   - "2.7"
+  - "pypy"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
   - pip install --upgrade pip setuptools


### PR DESCRIPTION
In my test pypy seemed to pass and the test finished faster than CPython 2.6 & 2.7.
