### PR TITLE
.travis.yml: enable fast finish & disable emails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,10 @@ install:
 # command to run tests, e.g. python setup.py test
 script: nosetests
 notifications:
+  email: false
   irc:
     channels:
       - "irc.nerv.fi#pyfibot"
     skip_join: true
+matrix:
+  fast_finish: true


### PR DESCRIPTION
I think that email notifications aren't really needed as same status changes are also announced at IRC and they are shown on GitHub pull request page.

Fast finish makes the build to be marked as failed immediately if one job fails instead of waiting for all jobs to be finished.

If build is marked as failed and all jobs haven't finished yet, they will continue building until they succeed or fail or timeout.