### PR TITLE
README.md: convert to real markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,51 +1,53 @@
 pyfibot
 =======
 
-A Python IRC-bot made using the <a href="http://twistedmatrix.com/trac/">Twisted Matrix</a> IRC-library.
+A Python IRC-bot made using the [Twisted Matrix](http://twistedmatrix.com/trac/) IRC-library.
 
-Supports online module reloading - only major core changes require a restart. Extensive module & handler -support for easy extension and customization.
+Supports online module reloading - only major core changes require a
+restart. Extensive module & handler -support for easy extension and
+customization.
 
 Installation
 ------------
-<a href="https://github.com/lepinkainen/pyfibot/wiki/Installation">Installation instructions</a>
+
+[Installation instructions](https://github.com/lepinkainen/pyfibot/wiki/Installation)
 
 Module highlights
----------------
-<ul id="highlights">
-   <li>URL title fetching with custom handlers via API calls for speed and efficiency
-       <ul>
-           <li>IMDb
-           <li>Youtube / Dailymotion / Liveleak
-           <li>Wikipedia
-           <li>Imgur
-           <li>Instagram
-           <li>eBay
-           <li>Spotify
-       </ul>
-   </li>
-   <li>Bitcoin exchange rates
-   <li>Wolfram Alpha queries
-   <li>Weather
-   <li>RSS support
-</ul>
+-----------------
+
+* URL title fetching with custom handlers via API calls for speed and
+efficiency
+    * IMDb
+    * Youtube / Dailymotion / Liveleak
+    * Wikipedia
+    * Imgur
+    * Instagram
+    * eBay
+    * Spotify
+* Bitcoin exchange rates
+* Wolfram Alpha queries
+* Weather
+* RSS support
 
 Features
 --------
-<ul id="features">
-    <li>Modular</li>
-    <li>Live refresh of modules and configuration</li>
-    <li>Coder friendly (a basic module requires just 2 lines of boilerplate code)</li>
-    <li>SSL-support</li>
-    <li>IPv6-support</li>
-    <li>virtualenv-support</li>
-    <li>Works with torify</li>
-</ul>
 
-<p id="help">Support can be found at #pyfibot on irc.nerv.fi and please contact yllapito@nerv.fi if you want to connect outside of Finland (will be changed) or need help with IRC-network.</p>
+* Modular
+    * Live refresh of modules and configuration
+    * Coder friendly (a basic module requires just 2 lines of boilerplate
+    code)
+    * SSL-support
+    * IPv6-support
+    * virtualenv-support
+    * Works with torify
+
+Support can be found at #pyfibot on irc.nerv.fi and please contact
+yllapito@nerv.fi if you want to connect outside of Finland (will be 
+changed) or need help with IRC-network.
 
 [![Build Status](https://travis-ci.org/lepinkainen/pyfibot.png?branch=master)](https://travis-ci.org/lepinkainen/pyfibot)
 
-This product includes GeoLite data created by MaxMind, available from <a href="http://www.maxmind.com">http://www.maxmind.com</a>.
+This product includes GeoLite data created by MaxMind, available from [http://www.maxmind.com](http://maxmind.com/).
 
 
 [![Bitdeli Badge](https://d2weczhvl823v0.cloudfront.net/lepinkainen/pyfibot/trend.png)](https://bitdeli.com/free "Bitdeli Badge")


### PR DESCRIPTION
Previously this was HTML which was partially difficult to read from terminal.
