### PR TITLE
PEP8 fixes

### DIFF
--- a/pyfibot/modules/available/module_dhl.py
+++ b/pyfibot/modules/available/module_dhl.py
@@ -7,30 +7,33 @@ from __future__ import unicode_literals
 from datetime import datetime, timedelta
 from bs4 import BeautifulSoup
 
+
 def command_dhl(bot, user, channel, args):
     """Get latest status of a shipment by DHL shipment number"""
 
-    url = 'https://nolp.dhl.de/nextt-online-public/set_identcodes.do?lang=en&idc=%s'
-    r = bot.get_url(url % args)
+    payload = {'lang': 'en', 'idc': args}
+    url = 'https://nolp.dhl.de/nextt-online-public/set_identcodes.do'
+    r = bot.get_url(url, params=payload)
     bs = BeautifulSoup(r.content)
 
-    status_div = bs.find('div', {'class':'accordion-inner'})
+    status_div = bs.find('div', {'class': 'accordion-inner'})
     if status_div:
         status_table = status_div.find('tbody')
     else:
         return bot.say(channel, "Shipment with that number does not exist or an error occurred.")
     status_row = None
+
     for row in status_table.find_all('tr'):
         try:
-             status_row = row.find_all('td')
+            status_row = row.find_all('td')
         except:
-             continue
+            continue
 
     date_str = status_row[0].text.strip()
     place = status_row[1].text.strip()
     status = status_row[2].text.strip()
     dt = datetime.now() - datetime.strptime(date_str[5:], '%d.%m.%Y %H:%M h')
-            
+
     next_step = bs.find('td', text='Next step')
     if next_step:
         status += ' - Next step: %s' % next_step.next.next.next.next.strip()


### PR DESCRIPTION
now:

```
module_dhl.py:23:80: E501 line too long (97 > 79 characters)
module_dhl.py:51:80: E501 line too long (88 > 79 characters)
```

was:

```
module_dhl.py:10:1: E302 expected 2 blank lines, found 1
module_dhl.py:13:80: E501 line too long (84 > 79 characters)
module_dhl.py:17:41: E231 missing whitespace after ':'
module_dhl.py:21:80: E501 line too long (97 > 79 characters)
module_dhl.py:25:14: E111 indentation is not a multiple of four
module_dhl.py:27:14: E111 indentation is not a multiple of four
module_dhl.py:33:1: W293 blank line contains whitespace
module_dhl.py:48:80: E501 line too long (88 > 79 characters)
```

lines over 79 chars seem to be quite usual in pyfibot files
