### PR TITLE
Add .strip() for Twitter screenname and tweet content

### DIFF
--- a/pyfibot/modules/module_urltitle.py
+++ b/pyfibot/modules/module_urltitle.py
@@ -391,9 +391,9 @@ def _handle_tweet(url):
             log.warning("Error reading tweet (code %s) %s" % (error['code'], error['message']))
         return
 
-    text = tweet['text']
+    text = tweet['text'].strip()
     user = tweet['user']['screen_name']
-    name = tweet['user']['name']
+    name = tweet['user']['name'].strip()
 
     #retweets  = tweet['retweet_count']
     #favorites = tweet['favorite_count']


### PR DESCRIPTION
Fixes this behaviour:

```
<@pyfibot> Title: @missyjack (Sister Jules ): To those who make scifi
           TV/movies - this is what real scientists who have just
           launched a Mars mission look like http://t.co/NZQW9z5aBS
```
