### PR TITLE
Improve hitbox.tv URL regex

### DIFF
--- a/pyfibot/modules/module_urltitle.py
+++ b/pyfibot/modules/module_urltitle.py
@@ -1180,7 +1180,7 @@ def _handle_hitbox(url):
         return
 
     # Hitbox titles are populated by JavaScript so they return a useless "{{meta.title}}", don't show those
-    elif not re.match("http://(www\.)?hitbox\.tv/([a-z0-9]+)$", url):
+elif not re.match("http://(www\.)?hitbox\.tv/([A-Za-z0-9]+)$", url):
         return False
 
     # For actual stream pages, let's fetch information via the hitbox API


### PR DESCRIPTION
If someone has a mixed case username in Hitbox.tv (eg. "PlaYerX"), it will usually be appended into share link without modification when advertising the channel, like so: `http://www.hitbox.tv/PlaYerX`. This commit makes the bot recognize those URLs too.