### PR TITLE
Improve Hitbox.tv URL regex (another try)

### DIFF
--- a/pyfibot/modules/module_urltitle.py
+++ b/pyfibot/modules/module_urltitle.py
@@ -1180,7 +1180,7 @@ def _handle_hitbox(url):
         return
 
     # Hitbox titles are populated by JavaScript so they return a useless "{{meta.title}}", don't show those
-elif not re.match("http://(www\.)?hitbox\.tv/([A-Za-z0-9]+)$", url):
+    elif not re.match("http://(www\.)?hitbox\.tv/([A-Za-z0-9]+)$", url):
         return False
 
     # For actual stream pages, let's fetch information via the hitbox API

--- a/pyfibot/modules/module_urltitle.py
+++ b/pyfibot/modules/module_urltitle.py
@@ -1180,7 +1180,7 @@ def _handle_hitbox(url):
         return
 
     # Hitbox titles are populated by JavaScript so they return a useless "{{meta.title}}", don't show those
-    elif not re.match("http://(www\.)?hitbox\.tv/([a-z0-9]+)$", url):
+elif not re.match("http://(www\.)?hitbox\.tv/([A-Za-z0-9]+)$", url):
         return False
 
     # For actual stream pages, let's fetch information via the hitbox API


### PR DESCRIPTION
This commit fixes the indentation error in f974c123eb08ea9f5d59ee4f43597dcccb66d435. Tested with pylint just in case. :smile: 