### PR TITLE
Add dependencies to make Requests use PyOpenSSL by default

### DIFF
--- a/pyfibot/modules/module_urltitle.py
+++ b/pyfibot/modules/module_urltitle.py
@@ -10,6 +10,7 @@ import fnmatch
 import urlparse
 import logging
 import re
+import sys
 from datetime import datetime
 import math
 
@@ -18,6 +19,11 @@ from types import TupleType
 from repoze.lru import ExpiringLRUCache
 
 from bs4 import BeautifulSoup
+
+use_lxml = False
+if sys.hexversion < 0x02070000:
+    import lxml
+    use_lxml = True
 
 log = logging.getLogger("urltitle")
 config = None
@@ -63,7 +69,10 @@ def __get_bs(url):
 
     content = r.content
     if content:
-        return BeautifulSoup(content)
+        if use_lxml:
+            return BeautifulSoup(content, 'lxml')
+        else:
+            return BeautifulSoup(content)
     return None
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,8 @@ pyyaml
 jsonschema >= 1.0.0
 beautifulsoup4
 pyopenssl
+ndg-httpsclient
+pyasn1
 tvdb_api
 repoze.lru
 pygeoip

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ httplib2 >= 0.8.0
 feedparser >= 5.1.3
 service_identity
 python-dateutil >= 2.2
+lxml; python_version < '2.7'


### PR DESCRIPTION
Requests uses PyOpenSSL by default if it and necessary requirements are available.

From [urllib3's documentation](https://urllib3.readthedocs.org/en/latest/security.html):

> By default, we use the standard library’s `ssl` module. Unfortunately, there are several limitations which are addressed by PyOpenSSL:
> 
> * (Python 2.x) SNI support.
> * (Python 2.x-3.2) Disabling compression to mitigate CRIME attack.
> To use the Python OpenSSL bindings instead, you’ll need to install the required packages:
> 
> ```
> $ pip install pyopenssl ndg-httpsclient pyasn1
> ```
