### PR TITLE
Remove unnecessary version check, make BS use lxml always if present

### DIFF
--- a/pyfibot/modules/module_urltitle.py
+++ b/pyfibot/modules/module_urltitle.py
@@ -20,10 +20,6 @@ from repoze.lru import ExpiringLRUCache
 
 from bs4 import BeautifulSoup
 
-use_lxml = False
-if sys.hexversion < 0x02070000:
-    import lxml
-    use_lxml = True
 
 log = logging.getLogger("urltitle")
 config = None
@@ -69,10 +65,7 @@ def __get_bs(url):
 
     content = r.content
     if content:
-        if use_lxml:
-            return BeautifulSoup(content, 'lxml')
-        else:
-            return BeautifulSoup(content)
+        return BeautifulSoup(content)
     return None
 
 


### PR DESCRIPTION
Version check is unnecessary since BS always uses the best parser available and lxml is installed by default for older Python versions. Anyway the bot should use lxml always when it's installed, since it is a lot faster.

From [Beautiful Soup's documentation](http://www.crummy.com/software/BeautifulSoup/bs4/doc/#specifying-the-parser-to-use):

> If you don’t specify anything, you’ll get the best HTML parser that’s installed. Beautiful Soup ranks lxml’s parser as being the best, then html5lib’s, then Python’s built-in parser.