### PR TITLE
Titlehandler for python.org

### DIFF
--- a/pyfibot/modules/module_urltitle.py
+++ b/pyfibot/modules/module_urltitle.py
@@ -1301,6 +1301,15 @@ def _handle_steamstore(url):
     return "%s | %s" % (name, price)
 
 
+def _handle_pythonorg(url):
+    """http*://*python.org/*"""
+    title = __get_title_tag(url)
+    if title == 'Welcome to Python.org':
+        return False
+
+    return title.replace(' | Python.org', '')
+
+
 def _handle_github(url):
     """http*://*github.com*"""
     return __get_title_tag(url)


### PR DESCRIPTION
`og:title`s at python.org are really broken (issue opened: python/pythondotorg#756), for example on [this page](https://www.python.org/dev/peps/pep-0448/):
```html
<title>PEP 0448 -- Additional Unpacking Generalizations | Python.org</title>
<meta property="og:title" content="Welcome to Python.org">
```

So `og:title` isn't a suitable source for a title. Fixing it would require a lot of refactoring and since I don't have nearly any knowledge about Django templating I probably won't do it. Also few people probably are even interested in that amount of refactoring so I don't expect it being fixed soon.

In the meantime a titlehandler would be a suitable solution.