### PR TITLE
Add titlehandler for Discogs, improve bot_mock.py

### DIFF
--- a/pyfibot/modules/module_urltitle.py
+++ b/pyfibot/modules/module_urltitle.py
@@ -1301,6 +1301,68 @@ def _handle_steamstore(url):
     return "%s | %s" % (name, price)
 
 
+def _handle_discogs(url):
+    """http://*discogs.com/*"""
+
+    apiurl = 'https://api.discogs.com/'
+    headers = { 'user-agent': 'pyfibot-urltitle' }
+
+    title_formats = {
+        'release': '{0[artists][0][name]} - {0[title]} - ({0[year]}) - {0[labels][0][catno]}',
+        'artist': '{0[name]}',
+        'label': '{0[name]}',
+        'master': '{0[artists][0][name]} - {0[title]} - ({0[year]})',
+    }
+
+    m = re.match('http:\/\/(?:www\.)?discogs\.com\/(?:([A-Za-z0-9-]+)\/)?(release|master|artist|label|item|seller|user)\/(\d+|[A-Za-z0-9_.-]+)', url)
+
+    if m:
+        m = m.groups()
+        if m[1] in title_formats:
+            endpoint = '%ss/%s' % (m[1], m[2])
+            data = bot.get_url('%s%s' % (apiurl, endpoint),
+                               headers=headers).json()
+
+            title = title_formats[m[1]].format(data)
+
+        elif m[1] in ['seller', 'user']:
+            endpoint = 'users/%s' % m[2]
+            data = bot.get_url('%s%s' % (apiurl, endpoint),
+                               headers=headers).json()
+
+            title = ['{0[name]}']
+
+            if data['num_for_sale'] > 0:
+                plural = 's' if data['num_for_sale'] > 1 else ''
+                title.append('{0[num_for_sale]} item%s for sale' % plural)
+
+            if data['releases_rated'] > 10:
+                title.append('Rating avg: {0[rating_avg]} (total {0[releases_rated]})')
+
+            title = ' - '.join(title).format(data)
+
+        elif m[0:2] == ['sell', 'item']:
+            endpoint = 'marketplace/listings/%s' % m[2]
+            data = bot.get_url('%s%s' % (apiurl, endpoint)).json()
+
+            for field in ('condition', 'sleeve_condition'):
+                if field in ['Generic', 'Not Graded', 'No Cover']:
+                    data[field] = field
+                else:
+                    m = re.match('(?:\w+ )+\(([A-Z]{1,2}[+-]?)( or M-)?\)',
+                                 data[field])
+                    data[field] = m.group(1)
+
+            fmt = ('{0[release][description]} [{0[price][value]}'
+                   '{0[price][currency]} - ships from {0[ships_from]} - '
+                   'Condition: {0[condition]}/{0[sleeve_condition]}]')
+
+            title = fmt.format(data)
+
+    if title:
+        return title
+
+
 def _handle_github(url):
     """http*://*github.com*"""
     return __get_title_tag(url)

--- a/tests/test_urltitle.py
+++ b/tests/test_urltitle.py
@@ -142,7 +142,7 @@ def test_discogs_release():
     msg = "http://www.discogs.com/release/249504"
     module_urltitle.init(bot)
     eq_(("#channel", "Title: %s" % title), module_urltitle.handle_url(bot, None, "#channel", msg, msg))
-    sleep(1.5)
+    sleep(3)
 
 
 def test_discogs_user():

--- a/tests/test_urltitle.py
+++ b/tests/test_urltitle.py
@@ -4,9 +4,11 @@ from nose.tools import eq_, ok_
 import bot_mock
 from pyfibot.modules import module_urltitle
 from utils import check_re
+from time import sleep
 
 
 bot = bot_mock.BotMock()
+
 
 lengh_str_regex = '\d+(h|m|s)(\d+(m))?(\d+s)?'
 views_str_regex = '\d+(\.\d+)?(k|M|Billion|Trillion)?'
@@ -131,3 +133,20 @@ def test_steamstore():
     module_urltitle.init(bot)
     eq_(title, module_urltitle.handle_url(bot, None, "#channel", msg, msg)[1])
 
+
+# Only a couple of tests and 1.5s sleep because rate is limited to
+# 1 request/sec/ip; if an API breaks, it often breaks completely.
+
+def test_discogs_release():
+    title = "Rick Astley - Never Gonna Give You Up - (1987) - PB 41447"
+    msg = "http://www.discogs.com/release/249504"
+    module_urltitle.init(bot)
+    eq_(("#channel", "Title: %s" % title), module_urltitle.handle_url(bot, None, "#channel", msg, msg))
+    sleep(1.5)
+
+
+def test_discogs_user():
+    regex = ".+Rating avg: \d\.\d\d \(total \d+\)"
+    msg = "http://www.discogs.com/user/rodneyfool"
+    module_urltitle.init(bot)
+    check_re(regex, module_urltitle.handle_url(bot, None, "#channel", msg, msg)[1])


### PR DESCRIPTION
Adds titlehandler for Discogs providing more specific titles for music enthusiasts, for example:
```
<user> http://www.discogs.com/release/249504
<pyfibot> Title: Rick Astley - Never Gonna Give You Up - (1987) - PB 41447
```
(Info: `album artist - album name - (year) - release identifier`)

Also improves `get_url()` in `bot_mock.py` to support everything that real bot does too.