### PR TITLE
Update requirements.txt to reflect syntax changes in pip 7.0.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ httplib2 >= 0.8.0
 feedparser >= 5.1.3
 service_identity
 python-dateutil >= 2.2
-lxml; python_version < '2.7'
+"lxml; python_version < '2.7'"


### PR DESCRIPTION
From [pip 7.0.0 release notes](https://pip.pypa.io/en/latest/news.html):

> - **BACKWARD INCOMPATIBLE** Requirements in requirements files containing markers must now be quoted due to parser changes from ([PR #2697](https://github.com/pypa/pip/pull/2697)) and ([PR #2725](https://github.com/pypa/pip/pull/2725)). For example, use `"SomeProject; python_version < '2.7'"`, not simply `SomeProject; python_version < '2.7'`