### PR TITLE
Pip reversed the quoting requirement, changing back...

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,4 +18,4 @@ httplib2 >= 0.8.0
 feedparser >= 5.1.3
 service_identity
 python-dateutil >= 2.2
-"lxml; python_version < '2.7'"
+lxml; python_version < '2.7'


### PR DESCRIPTION
> __7.0.2 (2015-06-01)__
> - __BACKWARD INCOMPATIBLE__ Revert the change (released in v7.0.0) that required quoting in requirements files around specifiers containing environment markers. (PR #2841)