### PR TITLE
Better Gfycat handling, add tests

### DIFF
--- a/pyfibot/modules/module_urltitle.py
+++ b/pyfibot/modules/module_urltitle.py
@@ -1397,23 +1397,33 @@ def _handle_gitio(url):
     return __get_title_tag(url)
 
 def _handle_gfycat(url):
-    """http*://gfycat.com/*"""
+    """http*://*gfycat.com/*"""
 
     api_url = "https://gfycat.com/cajax/get/%s"
 
-    m = re.match("https?://gfycat.com/([\w]+)", url)
+    m = re.match("https?://(?:\w+\.)?gfycat.com/([\w]+)(?:\.gif|\.webm|\.mp4)?", url)
     if not m: return
 
     r = bot.get_url(api_url % m.group(1))
     j = r.json()['gfyItem']
 
-
     title = []
-    if j['redditId']:
-        # http://reddit.com/r/all/comments/3us0ts/girls_day_low_angle_shot
-        baseurl = "https://reddit.com/r/%s/%s/%s"
-        url = baseurl % (j['subreddit'], j['redditId'], j['redditIdText'])
-        title.append(url)
+    if j['title']:
+        title.append(j['title'])
+    elif j['redditId']:
+        try:
+            baseurl = "https://www.reddit.com/r/%s/comments/%s/%s/.json"
+            url = baseurl % (j['subreddit'], j['redditId'], j['redditIdText'])
+
+            r = bot.get_url(url)
+            data = r.json()[0]['data']['children'][0]['data']
+
+            title.append(data['title'])
+        except:
+            pass
+
+    if j['subreddit']:
+        title.append("(/r/%s)" % j['subreddit'])
 
     title.append("%sx%s@%sfps" % (j['width'], j['height'], j['frameRate']))
     title.append("%s views" % j['views'])

--- a/tests/test_urltitle.py
+++ b/tests/test_urltitle.py
@@ -157,3 +157,22 @@ def test_discogs_user():
     msg = "http://www.discogs.com/user/rodneyfool"
     module_urltitle.init(bot)
     check_re(regex, module_urltitle.handle_url(bot, None, "#channel", msg, msg)[1])
+
+
+def test_gfycat_reddit_title():
+    regex = "Title: California Sunset \(/r/NatureGifs\) 1280x720@29fps \d+ views"
+    msg = "http://www.gfycat.com/ZanyFragrantHoneyeater"
+    module_urltitle.init(bot)
+    check_re(regex, module_urltitle.handle_url(bot, None, "#channel", msg, msg)[1])
+
+
+def test_gfycat_own_title():
+    regex = "Title: Star Trail's in the Desert 632x480@30fps \d+ views"
+    msg = "https://www.gfycat.com/EcstaticWelllitHarpseal"
+    module_urltitle.init(bot)
+    check_re(regex, module_urltitle.handle_url(bot, None, "#channel", msg, msg)[1])
+
+
+def test_gfycat_direct_url():
+    regex = "Title: \(/r/NatureGifs\) 270x480@30fps \d+ views"
+    msg = "https://zippy.gfycat.com/QualifiedSpanishAmericankestrel.webm"


### PR DESCRIPTION
* Add support for direct urls to files and www-prefixed Gfys
  * `https://zippy.gfycat.com/QualifiedSpanishAmericankestrel.webm`
  * `https://www.gfycat.com/EcstaticWelllitHarpseal`
* If the Gfy has a title, show it. Otherwise show the title of the associated Reddit topic when available.
* If the Gfy is associated with a subreddit, show it in the title.
  * `Title: California Sunset (/r/NatureGifs) 1280x720@29fps 505 views`