### PR TITLE
Remove Travis tests for 2.6 and PyPy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: python
 sudo: false
 python:
-  - "2.6"
   - "2.7"
-  - "pypy"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
   - pip install --upgrade pip setuptools


### PR DESCRIPTION
* Twisted has dropped the support for Python 2.6. Pyfibot is (obviously) quite useless without Twisted.
* Travis does not have other options than `"pypy"` and `"pypy3"` and the [build is failing because Travis has too old PyPy for `cryptography`.](https://travis-ci.org/lepinkainen/pyfibot/jobs/95401431) I assume there's no workaround for this.