### PR TITLE
Add --user flag to pip install commands

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python:
   - "2.7"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install:
-  - pip install --upgrade pip setuptools
-  - pip install -r requirements.txt
+  - pip install --user --upgrade pip setuptools
+  - pip install --user -r requirements.txt
 # command to run tests, e.g. python setup.py test
 script: nosetests
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ python:
 install:
   - pip install --user --upgrade pip setuptools
   - pip install --user -r requirements.txt
-  - pip install --user nosetests
+  - pip install --user nose
 # command to run tests, e.g. python setup.py test
 script: nosetests
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ python:
 install:
   - pip install --user --upgrade pip setuptools
   - pip install --user -r requirements.txt
+  - pip install --user nosetests
 # command to run tests, e.g. python setup.py test
 script: nosetests
 notifications:


### PR DESCRIPTION
From [pip install reference guide](https://pip.pypa.io/en/stable/reference/pip_install/#options):

* `--user`
  * Install to the Python user install directory for your platform.

Fixes [the Travis build #434](https://travis-ci.org/lepinkainen/pyfibot/builds/95410543) failing because Travis has an old version of pip and `pip install` tries to replace the system version using user privileges.