### PR TITLE
Fix InsecureRequestWarning

### DIFF
--- a/pyfibot/pyfibot.py
+++ b/pyfibot/pyfibot.py
@@ -228,7 +228,6 @@ class PyFiBotFactory(ThrottledClientFactory):
         browser = "Mozilla/5.0 (Windows NT 6.1; WOW64) AppleWebKit/537.11 (KHTML, like Gecko) Chrome/23.0.1271.95 Safari/537.11"
         # Common session for all requests
         s = requests.session()
-        s.verify = False
         s.stream = True  # Don't fetch content unless asked
         s.headers.update({'User-Agent': browser})
         # Custom headers from requester

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argparse >= 1.2.1
 twisted >= 12.0.0
-requests >= 2.0.0
+requests >= 2.1.0
 pyyaml
 jsonschema >= 1.0.0
 beautifulsoup4


### PR DESCRIPTION
  * Removed `s.verify = False` from pyfibot.py: SSL certificate verification is default behavior since requests 0.9.0
  * Increased minimum requests version to 2.1.0: SNI support is broken in (some of) the earlier version(s)