### PR TITLE
Feature/admin only commands

### DIFF
--- a/pyfibot/modules/module_admin.py
+++ b/pyfibot/modules/module_admin.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+"""
+    Example of admin only commands
+"""
+
+from __future__ import unicode_literals, print_function, division
+
+
+def admin_allow(bot, user, channel, args):
+    bot.say(channel, "Example of a command only allowed to an admin")


### PR DESCRIPTION
Added core functionability for admin-only commands

def admin_allow(bot, user, channel, args):
    bot.say(channel, "Example of a command only allowed to an admin")

Admin commands are invisible to normal user when "help" is triggered, whereas admin gets another row of commands available.