### PR TITLE
Dockerfile improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,28 @@
 FROM alpine
 MAINTAINER Riku Lindblad "riku.lindblad@gmail.com"
 
-RUN apk add --update \
-    python \
-    python-dev \
-    build-base \
-    git \
-    py-pip \
-    openssl-dev \
-    libxml2-dev \
-    libxslt-dev \
-    libssl1.0 \
-    libffi-dev
+RUN set -x \
+    && apk add --no-cache --virtual .runtime-deps \
+        python \
+        libssl1.0 \
+        ca-certificates \
+    && apk add --no-cache --virtual .build-deps \
+        python-dev \
+        build-base \
+        git \
+        py-pip \
+        openssl-dev \
+        libxml2-dev \
+        libxslt-dev \
+        libffi-dev \
+    && git clone https://github.com/lepinkainen/pyfibot.git /pyfibot \
+    && rm -rf /pyfibot/.git \
+    && cd /pyfibot \
+    && pip install --upgrade -r requirements.txt \
+    && apk del .build-deps \
+    && mkdir /config
 
-RUN pip install --upgrade pip
-
-RUN git clone https://github.com/lepinkainen/pyfibot.git
-WORKDIR pyfibot
-RUN pip install --upgrade -r requirements.txt
-
-RUN mkdir /config
-
+WORKDIR /pyfibot
 VOLUME /config
 
 ENTRYPOINT ["pyfibot/pyfibot.py", "/config/config.yml"]


### PR DESCRIPTION
Improves project `Dockerfile` by running all container build steps in a single layer. Runtime and build requirements are split into virtual packages, so build related packages can be removed after running `pip install`. Packages `libssl1.0` and `ca-certificates` are not uninstalled to enable TLS certificate verification.

This reduces the final uncompressed Docker image size from 341 MB to 124 MB. Compressed image size reduced from 134 MB to 48 MB.