### PR TITLE
Handle YouTube API 'publishedAt' dates without dot

### DIFF
--- a/pyfibot/modules/module_urltitle.py
+++ b/pyfibot/modules/module_urltitle.py
@@ -574,8 +574,12 @@ def _handle_youtube_gdata(url):
 
         # Content age
         published = entry['snippet']['publishedAt']
-        published = datetime.strptime(published, "%Y-%m-%dT%H:%M:%S.%fZ")
-        agestr = __get_age_str(published)
+        try:
+            published = datetime.strptime(published, "%Y-%m-%dT%H:%M:%S.%fZ")
+        except ValueError: # Sometimes the decimal point is omitted
+            published = datetime.strptime(published, "%Y-%m-%dT%H:%M:%SZ")
+        finally:
+            agestr = __get_age_str(published)
 
         return "%s by %s [%s - %s views - %s%s]" % (
             title, channel, duration, views, agestr, agerestricted)


### PR DESCRIPTION
```
commit 71e03455e8076df301501893d9af2530f6e73d7d
Date:   Thu May 7 19:48:47 2020 +0300

    Handle YouTube API 'publishedAt' dates without dot
    
    Fixes error observed with https://www.youtube.com/watch?v=RcYjXbSJBN8
    
      Traceback: <type 'exceptions.ValueError'>: time data
      '2020-05-07T16:00:21Z' does not match format '%Y-%m-%dT%H:%M:%S.%fZ'
    
    Commit catches the ValueError and re-parses with '%Y-%m-%dT%H:%M:%SZ'.

 pyfibot/modules/module_urltitle.py | 8 ++++++--
 1 file changed, 6 insertions(+), 2 deletions(-)
```

```diff
-        published = datetime.strptime(published, "%Y-%m-%dT%H:%M:%S.%fZ")
-        agestr = __get_age_str(published)
+        try:
+            published = datetime.strptime(published, "%Y-%m-%dT%H:%M:%S.%fZ")
+        except ValueError: # Sometimes the decimal point is omitted
+            published = datetime.strptime(published, "%Y-%m-%dT%H:%M:%SZ")
+        finally:
+            agestr = __get_age_str(published)
```