### PR TITLE
Get <title> for Bitchute URLs (cuz og:titles suck)

### DIFF
--- a/pyfibot/modules/module_urltitle.py
+++ b/pyfibot/modules/module_urltitle.py
@@ -1573,6 +1573,9 @@ def _handle_gitio(url):
     """http*://git.io*"""
     return __get_title_tag(url)
 
+def _handle_bitchute(url):
+    """http*://*bitchute.com*"""
+    return __get_title_tag(url)
 
 def _handle_gfycat(url):
     """http*://*gfycat.com/*"""


### PR DESCRIPTION
For example, meta og:title shows the uploader's username on video pages.