### PR TITLE
Fix Steam title when price is not available

### DIFF
--- a/pyfibot/modules/module_urltitle.py
+++ b/pyfibot/modules/module_urltitle.py
@@ -1379,7 +1379,10 @@ def _handle_steamstore(url):
         if data['price_overview']['discount_percent'] != 0:
             price += " (-%s%%)" % data['price_overview']['discount_percent']
     else:
-        price = "Free to play"
+        if 'is_free' in data and data['is_free']:
+            price = "Free to play"
+        else:
+            price = "Price: N/A"
 
     return "%s | %s" % (name, price)
 


### PR DESCRIPTION
If a Steam store page doesn't have a price listed, like in the case of an unreleased game like https://store.steampowered.com/app/1003590/Tetris_Effect_Connected/ the bot would return the price as "Free to play". This change uses the "is_free" field to check if the game is actually free to play.